### PR TITLE
Fix schedule editing refresh

### DIFF
--- a/src/components/oni_agencia/content-schedule/control-pauta/ContentArea.tsx
+++ b/src/components/oni_agencia/content-schedule/control-pauta/ContentArea.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { Calendar } from "@/components/oni_agencia/content-schedule/calendar/Calendar";
 import { ContentScheduleList } from "@/components/oni_agencia/content-schedule/ContentScheduleList";
 import { CalendarEvent } from "@/types/oni-agencia";
@@ -30,6 +30,7 @@ interface ContentAreaProps {
   showLoadingState: boolean;
   isCollapsed: boolean;
   onManualRefetch?: () => void;
+  onDialogStateChange?: (open: boolean) => void;
 }
 
 export function ContentArea({ 
@@ -45,9 +46,9 @@ export function ContentArea({
   fetchNextPage,
   showLoadingState,
   isCollapsed,
-  onManualRefetch
+  onManualRefetch,
+  onDialogStateChange
 }: ContentAreaProps) {
-  const [dialogOpen, setDialogOpen] = useState(false);
   const {
     selectedEvent,
     selectedDate,
@@ -66,6 +67,20 @@ export function ContentArea({
     year,
     onManualRefetch
   });
+
+  const handleDialogOpen = (open: boolean) => {
+    handleDialogOpenChange(open);
+    if (onDialogStateChange) {
+      onDialogStateChange(open);
+    }
+  };
+
+  const handleDialogCloseWithNotify = () => {
+    handleDialogClose();
+    if (onDialogStateChange) {
+      onDialogStateChange(false);
+    }
+  };
   
   // Configure sensors with zero delay for better responsiveness
   const sensors = useCustomDndSensors(0, 3);
@@ -139,8 +154,8 @@ export function ContentArea({
             selectedDate={selectedDate}
             selectedEvent={selectedEvent}
             isDialogOpen={isDialogOpen}
-            onDialogOpenChange={handleDialogOpenChange}
-            onDialogClose={handleDialogClose}
+            onDialogOpenChange={handleDialogOpen}
+            onDialogClose={handleDialogCloseWithNotify}
             onManualRefetch={onManualRefetch}
           />
 

--- a/src/pages/oni_agencia/OniAgenciaControlePauta.tsx
+++ b/src/pages/oni_agencia/OniAgenciaControlePauta.tsx
@@ -17,6 +17,7 @@ const OniAgenciaControlePauta = () => {
   const [selectedCollaborator, setSelectedCollaborator] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"calendar" | "list">("calendar");
   const { isCollapsed, toggle: toggleFilters } = useCollapsible(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   
   // UseCallback for better performance
   const handleClientChange = useCallback((clientId: string) => {
@@ -69,16 +70,16 @@ const OniAgenciaControlePauta = () => {
   
   // Polling for automatic periodic updates
   useEffect(() => {
-    // Refetch data every 30 seconds
+    // Refetch data every 30 seconds when dialog is closed
     const intervalId = setInterval(() => {
-      if (selectedClient) {
+      if (selectedClient && !isDialogOpen) {
         console.log("Executando atualização automática periódica");
         handleManualRefetch();
       }
-    }, 30000); // 30 seconds
-    
+    }, 30000);
+
     return () => clearInterval(intervalId);
-  }, [queryClient, selectedClient, handleManualRefetch]);
+  }, [queryClient, selectedClient, handleManualRefetch, isDialogOpen]);
   
   return (
     <main className="container-fluid p-0 max-w-full">
@@ -123,6 +124,7 @@ const OniAgenciaControlePauta = () => {
           showLoadingState={showLoadingState}
           isCollapsed={isCollapsed}
           onManualRefetch={handleManualRefetch}
+          onDialogStateChange={setIsDialogOpen}
         />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add `onDialogStateChange` callback so `ContentArea` notifies parent when schedule dialog opens or closes
- pause automatic data refresh while the schedule dialog is open

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*